### PR TITLE
Use loop normals when vertex-normals are requested.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -118,6 +118,7 @@ class ExportB3D(bpy.types.Operator, ExportHelper):
     def execute(self, context):
         from . import export_b3d
 
+        export_b3d.b3d_parameters["vertex-normals"] = True
         export_b3d.b3d_parameters["export-selected"] = self.use_selection
 
         keywords = self.as_keywords(ignore=("filter_glob", "check_existing"))

--- a/export_b3d.py
+++ b/export_b3d.py
@@ -1092,6 +1092,7 @@ def write_node_mesh_vrts(obj, data, obj_count, arm_action, exp_root):
                 my_uvs[f.index].append(uv)
 
     uv_layers_count = len(getUVTextures(data))
+    data.calc_normals_split() # ensure loop normals are valid
     for face in getFaces(data):
         
         if DEBUG: print("        <!-- Face",face.index,"-->")
@@ -1102,8 +1103,10 @@ def write_node_mesh_vrts(obj, data, obj_count, arm_action, exp_root):
         
         per_face_vertices[face.index] = []
         
-        for vertex_id,vert in enumerate(face.vertices):
+        for vertex_id, loop_index in enumerate(face.loop_indices):
             
+            loop = data.loops[loop_index]
+            vert = loop.vertex_index
             ivert += 1
                         
             per_face_vertices[face.index].append(ivert)
@@ -1125,7 +1128,7 @@ def write_node_mesh_vrts(obj, data, obj_count, arm_action, exp_root):
             #time_in_a += b - a
             
             if b3d_parameters.get("vertex-normals"):
-                norm_matrix = mathutils.Matrix.Translation(data.vertices[vert].normal)
+                norm_matrix = mathutils.Matrix.Translation(loop.normal)
 
                 if arm_action:
                     norm_matrix @= mesh_matrix

--- a/export_b3d.py
+++ b/export_b3d.py
@@ -1130,11 +1130,9 @@ def write_node_mesh_vrts(obj, data, obj_count, arm_action, exp_root):
             if b3d_parameters.get("vertex-normals"):
                 norm_matrix = mathutils.Matrix.Translation(loop.normal)
 
-                if arm_action:
-                    norm_matrix @= mesh_matrix
-
                 norm_matrix @= TRANS_MATRIX
                 normal_vector = norm_matrix.to_translation()
+                normal_vector.normalize()
                 
                 temp_buf.append(write_float_triplet(normal_vector.x,  #NX
                                                     normal_vector.z,  #NY


### PR DESCRIPTION
This enables correct use of split normals and smooth/flat shading
