### PR TITLE
Proposal: New Forward Direction setting

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -51,7 +51,6 @@ from bpy_extras.io_utils import (
         )
 
 
-
 @orientation_helper(axis_forward="Y", axis_up="Z")
 class ImportB3D(bpy.types.Operator, ImportHelper):
     """Import from B3D file format (.b3d)"""

--- a/__init__.py
+++ b/__init__.py
@@ -51,6 +51,7 @@ from bpy_extras.io_utils import (
         )
 
 
+
 @orientation_helper(axis_forward="Y", axis_up="Z")
 class ImportB3D(bpy.types.Operator, ImportHelper):
     """Import from B3D file format (.b3d)"""
@@ -123,6 +124,19 @@ class ExportB3D(bpy.types.Operator, ExportHelper):
     use_local_transform: BoolProperty(
         name="Use Local Transform",
         description="Use local transforms with armatures",
+        default=False,
+    )
+
+
+    directions = [
+        ("+X", "+x", "", 1),
+        ("-X", "-x", "", 2),
+        ("+Y", "+y", "", 3),
+        ("-Y", "-y", "", 4),
+    ]
+    forward: EnumProperty(
+        name="Forward",
+        description="Choose which direction is forward",
         default=False,
     )
 

--- a/__init__.py
+++ b/__init__.py
@@ -128,17 +128,17 @@ class ExportB3D(bpy.types.Operator, ExportHelper):
     )
 
 
-    directions = [
-        ("+X", "+x", "", 1),
-        ("-X", "-x", "", 2),
-        ("+Y", "+y", "", 3),
-        ("-Y", "-y", "", 4),
-    ]
-    forward: EnumProperty(
-        name="Forward",
-        description="Choose which direction is forward",
-        default=False,
-    )
+    #directions = [
+    #    ("+X", "+x", "", 1),
+    #    ("-X", "-x", "", 2),
+    #    ("+Y", "+y", "", 3),
+    #    ("-Y", "-y", "", 4),
+    #]
+    #forward: EnumProperty(
+    #    name="Forward",
+    #    description="Choose which direction is forward",
+    #    default=False,
+    #)
 
     export_ambient: BoolProperty(
         name="Export Ambient Light",

--- a/__init__.py
+++ b/__init__.py
@@ -127,19 +127,6 @@ class ExportB3D(bpy.types.Operator, ExportHelper):
         default=False,
     )
 
-
-    #directions = [
-    #    ("+X", "+x", "", 1),
-    #    ("-X", "-x", "", 2),
-    #    ("+Y", "+y", "", 3),
-    #    ("-Y", "-y", "", 4),
-    #]
-    #forward: EnumProperty(
-    #    name="Forward",
-    #    description="Choose which direction is forward",
-    #    default=False,
-    #)
-
     export_ambient: BoolProperty(
         name="Export Ambient Light",
         description="Export world light color",
@@ -150,6 +137,17 @@ class ExportB3D(bpy.types.Operator, ExportHelper):
         name="Enable Mipmaps",
         description="Enables the mipmap flag on UV maps",
         default=False,
+    )
+
+    forward: EnumProperty(
+        items = [
+            ("+x", "+X", ""),
+            ("-x", "-X", ""),
+            ("+y", "+Y", ""),
+            ("-y", "-Y", ""),
+        ],
+        name="Forward",
+        description="Choose which direction is forward",
     )
 
     use_selection: BoolProperty(
@@ -229,6 +227,7 @@ class ExportB3D(bpy.types.Operator, ExportHelper):
         export_settings["use_local_transform"] = self.use_local_transform
         export_settings["export_ambient"] = self.export_ambient
         export_settings["enable_mipmaps"] = self.enable_mipmaps
+        export_settings["forward"] = self.forward
 
         export_settings["use_selection"] = self.use_selection
         export_settings["use_visible"] = self.use_visible
@@ -317,6 +316,7 @@ class B3D_PT_export_other(bpy.types.Panel):
         layout.prop(operator, "use_local_transform")
         layout.prop(operator, "export_ambient")
         layout.prop(operator, "enable_mipmaps")
+        layout.prop(operator, "forward")
 
 # Add to a menu
 def menu_func_export(self, context):

--- a/export_b3d.py
+++ b/export_b3d.py
@@ -928,8 +928,16 @@ def write_node_mesh_vrts(settings, obj, data, arm_action):
             vert_matrix @= TRANS_MATRIX
             vcoord = vert_matrix.to_translation()
 
-            temp_buf.append(write_float_triplet(vcoord.x, vcoord.z, vcoord.y))
-
+            forward_setting = settings.get("forward")
+            if forward_setting == "+y":
+                temp_buf.append(write_float_triplet(vcoord.x, vcoord.z, vcoord.y))
+            elif forward_setting == "-y":
+                temp_buf.append(write_float_triplet(-vcoord.x, vcoord.z, vcoord.y))
+            elif forward_setting == "-x":
+                temp_buf.append(write_float_triplet(vcoord.y, vcoord.z, -vcoord.x))
+            else:
+                temp_buf.append(write_float_triplet(vcoord.y, vcoord.z, vcoord.x))
+            
             if settings.get("export_normals"):
                 norm_matrix = mathutils.Matrix.Translation(loop.normal)
 
@@ -1125,10 +1133,26 @@ def write_node_node(settings, ibone):
 
     # FIXME: we should use the same matrix format everywhere to not require this
     position = matrix.to_translation()
+    forward_setting = settings.get("forward")
+    print(forward_setting)
     if bone[BONE_PARENT]:
-        temp_buf.append(write_float_triplet(-position[0], position[2], position[1]))
+        if forward_setting == "+y":
+            temp_buf.append(write_float_triplet(-position[0], position[2], position[1]))
+        elif forward_setting == "-y":
+            temp_buf.append(write_float_triplet(position[0], position[2], position[1]))
+        elif forward_setting == "-x":
+            temp_buf.append(write_float_triplet(-position[1], position[2], -position[0]))
+        else:
+            temp_buf.append(write_float_triplet(-position[1], position[2], position[0]))
     else:
-        temp_buf.append(write_float_triplet(position[0], position[2], position[1]))
+        if forward_setting == "+y":
+            temp_buf.append(write_float_triplet(position[0], position[2], position[1]))
+        elif forward_setting == "-y":
+            temp_buf.append(write_float_triplet(-position[0], position[2], position[1]))
+        elif forward_setting == "-x":
+            temp_buf.append(write_float_triplet(position[1], position[2], -position[0]))
+        else:
+            temp_buf.append(write_float_triplet(position[1], position[2], position[0]))
 
 
     scale = matrix.to_scale()
@@ -1185,14 +1209,36 @@ def write_node_keys(settings, ibone):
             temp_buf.append(write_int(keys_stack[ikeys][0])) #Frame
 
             position = keys_stack[ikeys][2]
+            forward_setting = settings.get("forward")
             # FIXME: we should use the same matrix format everywhere and not require this
             if settings.get("use_local_transform"):
                 if bone_stack[ibone][BONE_PARENT]:
-                    temp_buf.append(write_float_triplet(-position[0], position[2], position[1]))
+                    if forward_setting == "+y":
+                        temp_buf.append(write_float_triplet(-position[0], position[2], position[1]))
+                    elif forward_setting == "-y":
+                        temp_buf.append(write_float_triplet(position[0], position[2], position[1]))
+                    elif forward_setting == "-x":
+                        temp_buf.append(write_float_triplet(-position[1], position[2], -position[0]))
+                    else:
+                        temp_buf.append(write_float_triplet(-position[1], position[2], position[0]))
                 else:
-                    temp_buf.append(write_float_triplet(position[0], position[2], position[1]))
+                    if forward_setting == "+y":
+                        temp_buf.append(write_float_triplet(position[0], position[2], position[1]))
+                    elif forward_setting == "-y":
+                        temp_buf.append(write_float_triplet(-position[0], position[2], position[1]))
+                    elif forward_setting == "-x":
+                        temp_buf.append(write_float_triplet(position[1], position[2], -position[0]))
+                    else:
+                        temp_buf.append(write_float_triplet(position[1], position[2], position[0]))
             else:
-                temp_buf.append(write_float_triplet(-position[0], position[1], position[2]))
+                if forward_setting == "+y":
+                    temp_buf.append(write_float_triplet(-position[0], position[1], position[2]))
+                elif forward_setting == "-y":
+                    temp_buf.append(write_float_triplet(position[0], position[1], position[2]))
+                elif forward_setting == "-x":
+                    temp_buf.append(write_float_triplet(position[2], position[1], -position[0]))
+                else:
+                    temp_buf.append(write_float_triplet(position[2], position[1], position[0]))
 
             scale = keys_stack[ikeys][3]
             temp_buf.append(write_float_triplet(scale[0], scale[1], scale[2]))
@@ -1200,7 +1246,14 @@ def write_node_keys(settings, ibone):
             quat = keys_stack[ikeys][4]
             quat.normalize()
 
-            temp_buf.append(write_float_quad(quat.w, -quat.x, quat.y, quat.z))
+            if forward_setting == "+y":
+                temp_buf.append(write_float_quad(quat.w, -quat.x, quat.y, quat.z))
+            elif forward_setting == "-y":
+                temp_buf.append(write_float_quad(quat.w, quat.x, quat.y, quat.z))
+            elif forward_setting == "-x":
+                temp_buf.append(write_float_quad(quat.w, quat.z, quat.y, quat.x))
+            else:
+                temp_buf.append(write_float_quad(quat.w, quat.z, quat.y, -quat.x))
 
     keys_buf += write_chunk(b"KEYS",b"".join(temp_buf))
     temp_buf = []


### PR DESCRIPTION
## About
I hate rotating my models in blender just because they do not look in the right direction in minetest, this setting allows you to ignore the painful rotation and lets you set the direction your model is looking in during the export process.

<img width="225" alt="Screenshot 2023-06-04 at 1 55 30 PM" src="https://github.com/GreenXenith/io_scene_b3d/assets/85687254/70b970ca-2943-492c-8ae7-6f60bbf3ae3b">

