### PR TITLE
Blender 4.0 fix

### DIFF
--- a/B3DParser.py
+++ b/B3DParser.py
@@ -61,7 +61,7 @@ class B3DParser:
                     pos = self.f(2)
                     scale = self.f(2)
                     rot = self.f(1)[0]
-                    data.append(dotdict({'name':name,'position':pos,'scale':scale,'rotation':rot}))
+                    data.append(dotdict({'name':name,'position':pos,'scale':scale,'rotation':rot, 'flags':flags,'blend':blend}))
                 self.cb_data(chunk,{'textures':data})
 
             elif chunk=='BRUS':
@@ -229,5 +229,7 @@ if __name__ == '__main__':
     data = B3DTree().parse(filepath) # json tree
     import json
     print(json.dumps(data, indent=1))
+    #f = open(filepath+".json", "w")
+    #f.write(json.dumps(data, indent=1))
     #dump(data)
 


### PR DESCRIPTION
This fixes [Issue 10](https://github.com/GreenXenith/io_scene_b3d/issues/10), with the material index issues, and additionally fixes the blend method error when running in 4.0.
Additionally, it now imports vertex colours as colour attributes and creates and supports flags for the second uv channel (UV1).